### PR TITLE
Vectorization and yaml initialization

### DIFF
--- a/cp1616/CMakeLists.txt
+++ b/cp1616/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
 include_directories(${catkin_INCLUDE_DIRS})
 include_directories(${PROJECT_SOURCE_DIR}/include/)
 
-ADD_LIBRARY(Cp1616RosLib
+ADD_LIBRARY(cp1616
 	${PROJECT_SOURCE_DIR}/src/cp1616_io_controller.cpp
         ${PROJECT_SOURCE_DIR}/src/cp1616_io_controller_callbacks.cpp
         ${PROJECT_SOURCE_DIR}/src/cp1616_io_device.cpp
@@ -18,15 +18,15 @@ ADD_LIBRARY(Cp1616RosLib
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES Cp1616RosLib
+  LIBRARIES cp1616
   CATKIN_DEPENDS roscpp 
   DEPENDS libpnoiusr libl2interface 
 )
 
 add_executable(cp1616_test ${PROJECT_SOURCE_DIR}/src/cp1616_main.cpp)
-target_link_libraries (Cp1616RosLib yaml-cpp)	
+target_link_libraries (cp1616 yaml-cpp)	
 target_link_libraries(cp1616_test ${catkin_LIBRARIES} 
-                                  Cp1616RosLib
+                                  cp1616
                                   libpniousr.a
                                   libpniousr.so
                                   libl2interface.so 

--- a/cp1616/CMakeLists.txt
+++ b/cp1616/CMakeLists.txt
@@ -14,7 +14,8 @@ ADD_LIBRARY(Cp1616RosLib
         ${PROJECT_SOURCE_DIR}/src/cp1616_io_device.cpp
         ${PROJECT_SOURCE_DIR}/src/cp1616_io_device_callbacks.cpp
         )
-	  
+  
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES Cp1616RosLib
@@ -23,6 +24,7 @@ catkin_package(
 )
 
 add_executable(cp1616_test ${PROJECT_SOURCE_DIR}/src/cp1616_main.cpp)
+target_link_libraries (Cp1616RosLib yaml-cpp)	
 target_link_libraries(cp1616_test ${catkin_LIBRARIES} 
                                   Cp1616RosLib
                                   libpniousr.a

--- a/cp1616/config/test_io_controller_config.yaml
+++ b/cp1616/config/test_io_controller_config.yaml
@@ -1,43 +1,47 @@
-#Data comming from PROFINET network
-input:
-  module_1:
-    size: 4
-    starting_address: 4132
-    pub_topic: profinet_input_1
-        
-  module_2:
-    size: 4
-    starting_address: 4136
-    pub_topic: profinet_input_2
-    
-  module_3:
-    size: 4
-    starting_address: 4140
-    pub_topic: profinet_input_3
-    
-  module_4:
-    size: 16
-    starting_address: 4144
-    pub_topic: profinet_input_4
+- id: input_module_1
+  type: input
+  size: 4
+  starting_address: 4132
+  topic: profinet_input_1
 
-#Data being transmitted to PROFINET network    
-output:
-  module_1:
-    size: 4
-    starting_address: 4116
-    sub_topic: profinet_output_1
-    
-  module_2:
-    size: 4
-    starting_address: 4120
-    sub_topic: profinet_output_2
-    
-  module_3:
-    size: 4
-    starting_address: 4124
-    sub_topic: profinet_output_3
-    
-  module_4:
-    size: 16
-    starting_address: 4128
-    sub_topic: profinet_output_4
+- id: input_module_2
+  type: input
+  size: 4
+  starting_address: 4136
+  topic: profinet_input_2
+
+- id: input_module_3
+  type: input
+  size: 4
+  starting_address: 4140
+  topic: profinet_input_3
+
+- id: input_module_4
+  type: input
+  size: 16
+  starting_address: 4144
+  topic: profinet_input_4
+  
+- id: output_module_1
+  type: output
+  size: 4
+  starting_address: 4116
+  topic: profinet_output_1
+  
+- id: output_module_2
+  type: output
+  size: 4
+  starting_address: 4120
+  topic: profinet_output_2
+  
+- id: output_module_3
+  type: output
+  size: 4
+  starting_address: 4124
+  topic: profinet_output_3
+  
+- id: output_module_4
+  type: output
+  size: 16
+  starting_address: 4128
+  topic: profinet_output_4 

--- a/cp1616/config/test_io_controller_config.yaml
+++ b/cp1616/config/test_io_controller_config.yaml
@@ -1,0 +1,43 @@
+#Data comming from PROFINET network
+input:
+  module_1:
+    size: 4
+    starting_address: 4132
+    pub_topic: profinet_input_1
+        
+  module_2:
+    size: 4
+    starting_address: 4136
+    pub_topic: profinet_input_2
+    
+  module_3:
+    size: 4
+    starting_address: 4140
+    pub_topic: profinet_input_3
+    
+  module_4:
+    size: 16
+    starting_address: 4144
+    pub_topic: profinet_input_4
+
+#Data being transmitted to PROFINET network    
+output:
+  module_1:
+    size: 4
+    starting_address: 4116
+    sub_topic: profinet_output_1
+    
+  module_2:
+    size: 4
+    starting_address: 4120
+    sub_topic: profinet_output_2
+    
+  module_3:
+    size: 4
+    starting_address: 4124
+    sub_topic: profinet_output_3
+    
+  module_4:
+    size: 16
+    starting_address: 4128
+    sub_topic: profinet_output_4

--- a/cp1616/config/test_io_device_config.yaml
+++ b/cp1616/config/test_io_device_config.yaml
@@ -1,0 +1,26 @@
+modules:
+  module_1:
+    slot: 1
+    subslot: 1
+    modId: 0x19
+    subslotId: 0x010001
+    api: 0
+    maxSubslots: 0
+    modState: 0
+    substate: 0
+    dir: 0
+  
+  module_2:
+    slot: 2
+    subslot: 1
+    modId: 0x23
+    subslotId: 0x01
+    api: 0
+    maxSubslots: 0
+    modState: 0
+    substate: 0
+    dir: 0  
+  
+  
+  
+  

--- a/cp1616/config/test_io_device_config.yaml
+++ b/cp1616/config/test_io_device_config.yaml
@@ -1,25 +1,18 @@
-modules:
-  module_1:
-    slot: 1
-    subslot: 1
-    modId: 0x19
-    subslotId: 0x010001
-    api: 0
-    maxSubslots: 0
-    modState: 0
-    substate: 0
-    dir: 0
+- id: module_1
+  type: init
+  slot: 1
+  subslot: 1
+  modId: 0x19
+  subslotId: 0x00010001
   
-  module_2:
-    slot: 2
-    subslot: 1
-    modId: 0x23
-    subslotId: 0x01
-    api: 0
-    maxSubslots: 0
-    modState: 0
-    substate: 0
-    dir: 0  
+  
+- id: module_2
+  type: input
+  slot: 2
+  subslot: 1
+  modId: 0x23
+  subslotId: 0x01
+  
   
   
   

--- a/cp1616/include/cp1616/cp1616_io_controller.h
+++ b/cp1616/include/cp1616/cp1616_io_controller.h
@@ -190,9 +190,6 @@ private:
   static const int WAIT_FOR_CALLBACKS_PERIOD = 100000;
   static const int MAX_NUM_OF_INIT_ATTEMPTS = 1000;
   static const int INIT_DATA_VALUE = 0;
-    
-  static const std::string INPUT;
-  static const std::string OUTPUT;
   	  
 }; //cp1616_io_controller class
 

--- a/cp1616/include/cp1616/cp1616_io_controller.h
+++ b/cp1616/include/cp1616/cp1616_io_controller.h
@@ -60,10 +60,10 @@ class Cp1616IOController
 public:
 
   /**
-   * \brief Public instance accesssor
+   * \brief Public instance accesssors
    */
   static Cp1616IOController* getControllerInstance();
-  static Cp1616IOController* getControllerInstance(ros::NodeHandle *nh);  
+  static Cp1616IOController* getControllerInstance(std::string filepath);  
 
   /**
    * \brief Destructs an IOController object
@@ -156,7 +156,7 @@ public:
 
 private:
 
-  Cp1616IOController(ros::NodeHandle *nh);
+  Cp1616IOController(std::string filepath);
   static Cp1616IOController *controller_instance_;
 
   PNIO_UINT32 parseConfigFile(std::string filepath);
@@ -190,6 +190,9 @@ private:
   static const int WAIT_FOR_CALLBACKS_PERIOD = 100000;
   static const int MAX_NUM_OF_INIT_ATTEMPTS = 1000;
   static const int INIT_DATA_VALUE = 0;
+    
+  static const std::string INPUT;
+  static const std::string OUTPUT;
   	  
 }; //cp1616_io_controller class
 

--- a/cp1616/include/cp1616/cp1616_io_controller.h
+++ b/cp1616/include/cp1616/cp1616_io_controller.h
@@ -27,12 +27,25 @@
 #include "pniousrx.h"
 #include "pnioerrx.h"
 
-#define NUM_OF_INPUT_MODULES    4       //Fixed definitions for development purposes
-#define NUM_OF_OUTPUT_MODULES   4
-
 namespace cp1616
 {
 
+struct InputModuleData
+{
+  std::string module_id;
+  int size;
+  int starting_address;
+  std::string pub_topic;
+};
+
+struct OutputModuleData
+{
+  std::string module_id;
+  int size;
+  int starting_address;
+  std::string sub_topic;
+};
+  
 /**
  * \brief This class defines ROS-Profinet IO Controller implementation for communication processor Siemens CP1616
  */
@@ -45,6 +58,7 @@ public:
    * \brief Public instance accesssor
    */
   static Cp1616IOController* getControllerInstance();
+  static Cp1616IOController* getControllerInstance(ros::NodeHandle *nh);  
 
   /**
    * \brief Destructs an IOController object
@@ -137,12 +151,18 @@ public:
 
 private:
 
-  Cp1616IOController();
+  Cp1616IOController(ros::NodeHandle *nh);
   static Cp1616IOController *controller_instance_;
 
   PNIO_UINT32 cp_handle_;
   PNIO_UINT32 cp_id_;
  
+  unsigned int num_of_input_modules_;
+  unsigned int num_of_output_modules_;
+  
+  std::vector<InputModuleData> input_modules_;
+  std::vector<OutputModuleData> output_modules_;
+  
   int cp_ready_;
   int sem_mod_change_;
   volatile PNIO_MODE_TYPE cp_current_mode_;

--- a/cp1616/include/cp1616/cp1616_io_controller.h
+++ b/cp1616/include/cp1616/cp1616_io_controller.h
@@ -22,6 +22,9 @@
 #define CP1616_IO_CONTROLLER_H
 
 #include <ros/ros.h>
+#include <yaml-cpp/yaml.h>
+#include <iostream>
+#include <fstream>
 
 //IO base headers
 #include "pniousrx.h"
@@ -30,22 +33,24 @@
 namespace cp1616
 {
 
-struct InputModuleData
+/**
+ * \brief Struct to keep STEP7 module information parsed from yaml. config file
+ */
+  
+struct ControllerModuleData
 {
-  std::string module_id;
+  std::string id;
+  std::string type;
   int size;
   int starting_address;
-  std::string pub_topic;
+  std::string topic;
 };
 
-struct OutputModuleData
-{
-  std::string module_id;
-  int size;
-  int starting_address;
-  std::string sub_topic;
-};
-  
+/**
+ * \brief Overloading extraction operator for yaml parsing
+ */
+void operator >> (const YAML::Node &node, ControllerModuleData &module);
+
 /**
  * \brief This class defines ROS-Profinet IO Controller implementation for communication processor Siemens CP1616
  */
@@ -154,15 +159,17 @@ private:
   Cp1616IOController(ros::NodeHandle *nh);
   static Cp1616IOController *controller_instance_;
 
+  PNIO_UINT32 parseConfigFile(std::string filepath);
+  
   PNIO_UINT32 cp_handle_;
   PNIO_UINT32 cp_id_;
  
   unsigned int num_of_input_modules_;
   unsigned int num_of_output_modules_;
   
-  std::vector<InputModuleData> input_modules_;
-  std::vector<OutputModuleData> output_modules_;
-  
+  std::vector<ControllerModuleData> input_modules_;
+  std::vector<ControllerModuleData> output_modules_;
+   
   int cp_ready_;
   int sem_mod_change_;
   volatile PNIO_MODE_TYPE cp_current_mode_;
@@ -183,8 +190,9 @@ private:
   static const int WAIT_FOR_CALLBACKS_PERIOD = 100000;
   static const int MAX_NUM_OF_INIT_ATTEMPTS = 1000;
   static const int INIT_DATA_VALUE = 0;
-	  
+  	  
 }; //cp1616_io_controller class
+
 } //cp1616
 
 #endif //CP1616_IO_CONTROLLER_H

--- a/cp1616/include/cp1616/cp1616_io_device.h
+++ b/cp1616/include/cp1616/cp1616_io_device.h
@@ -93,7 +93,7 @@ public:
    * \brief Public instance accesssor
    */
   static Cp1616IODevice* getDeviceInstance();
-  static Cp1616IODevice* getDeviceInstance(ros::NodeHandle *nh);
+  static Cp1616IODevice* getDeviceInstance(std::string filepath);
   
   /**
    * \brief Destructs an IOController object
@@ -238,7 +238,7 @@ public:
   
 private:
   
-  Cp1616IODevice(ros::NodeHandle *nh);
+  Cp1616IODevice(std::string filepath);
   static Cp1616IODevice *device_instance_;
   
   PNIO_UINT32 parseConfigFile(std::string filepath);

--- a/cp1616/include/cp1616/cp1616_io_device.h
+++ b/cp1616/include/cp1616/cp1616_io_device.h
@@ -46,6 +46,9 @@
 #define INSTANCE_ID  0x0001
 
 #include <ros/ros.h>
+#include <yaml-cpp/yaml.h>
+#include <iostream>
+#include <fstream>
 
 //IO Base headers
 #include "pniobase.h"
@@ -56,11 +59,13 @@ namespace cp1616
 {
 
 /**
- * \brief Structure to keep STEP7 project data required for plugging modules and submodules
- * */
+ * \brief Struct to keep STEP7 module information parsed from yaml. config file
+ */
 
-struct DeviceData
+struct DeviceModuleData
 {
+  std::string id;
+  std::string type;
   int slot;
   int subslot;
   PNIO_UINT32 modId;
@@ -71,6 +76,11 @@ struct DeviceData
   int subState;
   int dir;
 };
+
+/**
+ * \brief Overloading extraction operator for yaml parsing
+ */
+void operator >> (const YAML::Node &node, DeviceModuleData &module);
 
 /**
  * \brief This class defines ROS-Profinet IO Device implementation for communication processor Siemens CP1616
@@ -181,11 +191,11 @@ public:
    * \return error_code (see pnioerrx.h for detailed description)
    */
   int doAfterIndataIndCbf();
-
+  
   /**
    * \brief pointer to device_data table which holds STEP7 configuration params
    */
-  DeviceData *p_device_data_;
+  DeviceModuleData *p_device_data_;
 
  /**
   * \brief Table of input controller data - IO Device output data
@@ -231,8 +241,10 @@ private:
   Cp1616IODevice(ros::NodeHandle *nh);
   static Cp1616IODevice *device_instance_;
   
+  PNIO_UINT32 parseConfigFile(std::string filepath);
+  
   int num_of_modules_;
-  std::vector<DeviceData> modules_;
+  std::vector<DeviceModuleData> modules_;
   
   PNIO_UINT32 cp_handle_;
   PNIO_UINT32 cp_id_;

--- a/cp1616/include/cp1616/cp1616_io_device.h
+++ b/cp1616/include/cp1616/cp1616_io_device.h
@@ -45,8 +45,6 @@
 #define DEVICE_ID    0x0003
 #define INSTANCE_ID  0x0001
 
-#define DEVICE_DATA_ENTRIES     2          // The total number of members of DEVICE_DATA structure  
-
 #include <ros/ros.h>
 
 //IO Base headers
@@ -63,8 +61,8 @@ namespace cp1616
 
 struct DeviceData
 {
-  unsigned int slot;
-  unsigned int subslot;
+  int slot;
+  int subslot;
   PNIO_UINT32 modId;
   PNIO_UINT32 subslotId;
   PNIO_UINT32 api;
@@ -85,7 +83,8 @@ public:
    * \brief Public instance accesssor
    */
   static Cp1616IODevice* getDeviceInstance();
-
+  static Cp1616IODevice* getDeviceInstance(ros::NodeHandle *nh);
+  
   /**
    * \brief Destructs an IOController object
    */
@@ -212,6 +211,7 @@ public:
   void setInputDataIops(int slot_number, int subslot_number, PNIO_IOXS status);   
   void setOutputDataIops(int slot_number, int subslot_number, PNIO_IOXS status);    
   
+  int getNumOfModules();
   int getArInfoIndFlag();
   int getPrmEndIndFlag();
   int getIndataIndFlag();
@@ -228,14 +228,15 @@ public:
   
 private:
   
-  Cp1616IODevice();
+  Cp1616IODevice(ros::NodeHandle *nh);
   static Cp1616IODevice *device_instance_;
+  
+  int num_of_modules_;
+  std::vector<DeviceData> modules_;
   
   PNIO_UINT32 cp_handle_;
   PNIO_UINT32 cp_id_;
-  unsigned int cp_number_of_slots_;
-  unsigned int cp_max_number_of_subslots_;
-
+  
   std::vector<std::vector<PNIO_UINT32> > input_data_length_;
   std::vector<std::vector<PNIO_IOXS> >   input_data_iocs_;
   std::vector<std::vector<PNIO_IOXS> >   input_data_iops_;
@@ -251,13 +252,14 @@ private:
   PNIO_UINT16 cp_session_key_;
   PNIO_UINT16 cp_ar_number_;
 
-  int idx_table_[DEVICE_DATA_ENTRIES];
+  std::vector<int> idx_table_;
   
+  static const int MAX_NUMBER_OF_SUBSLOTS = 1;
   static const int WAIT_FOR_CALLBACK_PERIOD = 100000;
   static const int MAX_PRM_END_COUNT = 500;
   static const int MAX_INDATA_IND_COUNT = 500;
   static const int MAX_OFFLINE_IND_COUNT = 100; 
-	 
+  	 
 }; //cp1616_io_device class
 }  //cp1616
 

--- a/cp1616/launch/test_io_controller.launch
+++ b/cp1616/launch/test_io_controller.launch
@@ -1,5 +1,7 @@
 <?xml version="1.0" ?>
 <launch>
   <node name="cp1616_test" pkg="cp1616" type="cp1616_test" output="screen"/>
-  <rosparam command="load" file="$(find cp1616)/config/test_io_controller_config.yaml"/>
+  <rosparam>
+    filepath: "/home/durovsky/catkin_ws/src/cp1616/cp1616/config/test_io_controller_config.yaml"
+  </rosparam>  
 </launch>

--- a/cp1616/launch/test_io_controller.launch
+++ b/cp1616/launch/test_io_controller.launch
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<launch>
+  <node name="cp1616_test" pkg="cp1616" type="cp1616_test" output="screen"/>
+  <rosparam command="load" file="$(find cp1616)/config/test_io_controller_config.yaml"/>
+</launch>

--- a/cp1616/launch/test_io_device.launch
+++ b/cp1616/launch/test_io_device.launch
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<launch>
+  <node name="cp1616_test" pkg="cp1616" type="cp1616_test" output="screen"/>
+  <rosparam command="load" file="$(find cp1616)/config/test_io_device_config.yaml"/>
+</launch>

--- a/cp1616/launch/test_io_device.launch
+++ b/cp1616/launch/test_io_device.launch
@@ -1,5 +1,7 @@
 <?xml version="1.0" ?>
 <launch>
   <node name="cp1616_test" pkg="cp1616" type="cp1616_test" output="screen"/>
-  <rosparam command="load" file="$(find cp1616)/config/test_io_device_config.yaml"/>
+  <rosparam>
+    filepath: "/home/durovsky/catkin_ws/src/cp1616/cp1616/config/test_io_device_config.yaml"
+  </rosparam>  
 </launch>

--- a/cp1616/src/cp1616_io_controller.cpp
+++ b/cp1616/src/cp1616_io_controller.cpp
@@ -29,8 +29,8 @@ namespace cp1616
 //Define and initialize controller instance_ to zero value
 Cp1616IOController *Cp1616IOController::controller_instance_ = 0;
 
-const std::string Cp1616IOController::INPUT = "input";
-const std::string Cp1616IOController::OUTPUT = "output";
+const std::string INPUT = "input";
+const std::string OUTPUT = "output";
 
 Cp1616IOController* Cp1616IOController::getControllerInstance(std::string filepath)
 {

--- a/cp1616/src/cp1616_io_device_callbacks.cpp
+++ b/cp1616/src/cp1616_io_device_callbacks.cpp
@@ -331,7 +331,7 @@ namespace pnio_device_callbacks
      
     // set local provider status preset values for all input/output slots
     // set local consumer status for all output slots
-    for(i = 0; i < DEVICE_DATA_ENTRIES ; i++)
+    for(i = 0; i < CallbackHandler->getNumOfModules(); i++)
     {
       for(j = 0; j < 1 /*g_device_data[i].maxSubslots*/; j++)
       {

--- a/cp1616/src/cp1616_main.cpp
+++ b/cp1616/src/cp1616_main.cpp
@@ -23,23 +23,25 @@
 #include <cp1616/cp1616_io_device.h>
 #include <cp1616/cp1616_io_device_callbacks.h>
 
-#define IO_CONTROLLER_MODE
-//#define IO_DEVICE_MODE
+//#define IO_CONTROLLER_MODE
+#define IO_DEVICE_MODE
 
 int main(int argc, char **argv)
 {
   ros::init(argc,argv, "cp1616");
   ros::NodeHandle nh;
-  ros::NodeHandle priv_nh_;
+  
+  std::string filepath;
+  nh.getParam("filepath", filepath);
 
 #ifdef IO_CONTROLLER_MODE
 
   //Create CP object
   cp1616::Cp1616IOController *cp1616_object;
-  cp1616_object = cp1616::Cp1616IOController::getControllerInstance(&priv_nh_);
+  cp1616_object = cp1616::Cp1616IOController::getControllerInstance(filepath);
 
   //Initialize and start CP
-/*  cp1616_object->init();
+  cp1616_object->init();
 
   if(cp1616_object->getCpReady() != 0)
   {
@@ -99,13 +101,13 @@ int main(int argc, char **argv)
  }
   //Uninitialize CP
   cp1616_object->uinit();
-*/
+
 #endif
 
 #ifdef IO_DEVICE_MODE
 
   cp1616::Cp1616IODevice *cp1616_object;
-  cp1616_object = cp1616::Cp1616IODevice::getDeviceInstance(&priv_nh_);
+  cp1616_object = cp1616::Cp1616IODevice::getDeviceInstance(filepath);
 
   int error_code;
 

--- a/cp1616/src/cp1616_main.cpp
+++ b/cp1616/src/cp1616_main.cpp
@@ -34,22 +34,12 @@ int main(int argc, char **argv)
 
 #ifdef IO_CONTROLLER_MODE
 
+  //Create CP object
   cp1616::Cp1616IOController *cp1616_object;
-  cp1616_object = cp1616::Cp1616IOController::getControllerInstance();
+  cp1616_object = cp1616::Cp1616IOController::getControllerInstance(&priv_nh_);
 
-  //Add IO modules
-  cp1616_object->addOutputModule(4,4116);
-  cp1616_object->addOutputModule(4,4120);
-  cp1616_object->addOutputModule(4,4124);
-  cp1616_object->addOutputModule(16,4128);
-
-  cp1616_object->addInputModule(4,4132);
-  cp1616_object->addInputModule(4,4136);
-  cp1616_object->addInputModule(4,4140);
-  cp1616_object->addInputModule(16,4144);
-
-  //Initialize CP
-  cp1616_object->init();
+  //Initialize and start CP
+/*  cp1616_object->init();
 
   if(cp1616_object->getCpReady() != 0)
   {
@@ -109,13 +99,13 @@ int main(int argc, char **argv)
  }
   //Uninitialize CP
   cp1616_object->uinit();
-
+*/
 #endif
 
 #ifdef IO_DEVICE_MODE
 
   cp1616::Cp1616IODevice *cp1616_object;
-  cp1616_object = cp1616::Cp1616IODevice::getDeviceInstance();
+  cp1616_object = cp1616::Cp1616IODevice::getDeviceInstance(&priv_nh_);
 
   int error_code;
 


### PR DESCRIPTION
This is current version of cp1616 software

Changes since last version : 
Added yaml initialization to both IO controller / IO device modes
NodeHandle is passed into constructor (through singleton initalization) to read rosparam and to create publishers/subsrcibers later
Almost all pointers are replaced by vectors now (`p_device_data` in IO device is an exception)

Issues:
I m not sure about `input_data`/ `output_data` representation in both modes (std::vector / std::array) public or private with encapsulation functions? 
